### PR TITLE
Make possible to use more than 1 constraint per scalar type

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const {
 } = require('apollo-server-koa')
 const ConstraintStringType = require('./scalars/string')
 const ConstraintNumberType = require('./scalars/number')
+const capitalize = require('capitalize')
 
 class ConstraintDirective extends SchemaDirectiveVisitor {
   static getDirectiveDeclaration (directiveName) {
@@ -74,8 +75,12 @@ class ConstraintDirective extends SchemaDirectiveVisitor {
       type = type.ofType
     }
 
-    if (isNamedType(type) && !typeMap[type.name]) {
-      typeMap[type.name] = type
+    if (isNamedType(type)) {
+      const typeName = capitalize(type.name)
+
+      if (!typeMap[typeName]) {
+        typeMap[typeName] = type
+      }
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class ConstraintDirective extends SchemaDirectiveVisitor {
     }
 
     if (isNamedType(type)) {
-      const typeName = capitalize(type.name)
+      const typeName = capitalize(type.name, true)
 
       if (!typeMap[typeName]) {
         typeMap[typeName] = type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-koa-constraint-directive",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1507,6 +1507,11 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
+    },
+    "capitalize": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-2.0.3.tgz",
+      "integrity": "sha512-Qc5ksT1/zEJBbFYD05h99hCNEW0cgyD0zzE5WvkgisNnppJ+16zfaSk34evF0j6pGW8hejkRUeygJ5uN5k22SQ=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "apollo-server-koa": "^2.11.0",
+    "capitalize": "^2.0.3",
     "validator": "^13.0.0",
     "zxcvbn": "^4.4.2"
   },

--- a/scalars/number.js
+++ b/scalars/number.js
@@ -5,7 +5,7 @@ const capitalize = require('capitalize')
 module.exports = class ConstraintNumberType extends GraphQLScalarType {
   constructor (fieldName, type, args) {
     super({
-      name: `Constraint${capitalize(fieldName)}`,
+      name: `Constraint${capitalize(fieldName, true)}`,
       serialize (value) {
         value = type.serialize(value)
         validate(fieldName, args, value)

--- a/scalars/number.js
+++ b/scalars/number.js
@@ -1,10 +1,11 @@
 const { GraphQLScalarType } = require('graphql')
 const ValidationError = require('../lib/error')
+const capitalize = require('capitalize')
 
 module.exports = class ConstraintNumberType extends GraphQLScalarType {
   constructor (fieldName, type, args) {
     super({
-      name: 'ConstraintNumber',
+      name: `Constraint${capitalize(fieldName)}`,
       serialize (value) {
         value = type.serialize(value)
         validate(fieldName, args, value)

--- a/scalars/string.js
+++ b/scalars/string.js
@@ -8,7 +8,7 @@ const capitalize = require('capitalize')
 module.exports = class ConstraintStringType extends GraphQLScalarType {
   constructor (fieldName, type, args) {
     super({
-      name: `Constraint${capitalize(fieldName)}`,
+      name: `Constraint${capitalize(fieldName, true)}`,
       serialize (value) {
         value = type.serialize(value)
         validate(fieldName, args, value)

--- a/scalars/string.js
+++ b/scalars/string.js
@@ -3,11 +3,12 @@ const { contains, isLength } = require('validator')
 const formats = require('./formats')
 const password = require('./password')
 const ValidationError = require('../lib/error')
+const capitalize = require('capitalize')
 
 module.exports = class ConstraintStringType extends GraphQLScalarType {
   constructor (fieldName, type, args) {
     super({
-      name: 'ConstraintString',
+      name: `Constraint${capitalize(fieldName)}`,
       serialize (value) {
         value = type.serialize(value)
         validate(fieldName, args, value)

--- a/test/__snapshots__/int.test.js.snap
+++ b/test/__snapshots__/int.test.js.snap
@@ -428,7 +428,7 @@ exports[`INPUT_FIELD_DEFINITION Int validate @constraint #exclusiveMax should fa
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value 3 at "input.title"; Expected type ConstraintNumber. Must be less than 3],
+    [GraphQLError: Variable "$input" got invalid value 3 at "input.title"; Expected type ConstraintTitle. Must be less than 3],
   ],
   "extensions": undefined,
   "http": Object {
@@ -458,7 +458,7 @@ exports[`INPUT_FIELD_DEFINITION Int validate @constraint #exclusiveMin should fa
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value 3 at "input.title"; Expected type ConstraintNumber. Must be greater than 3],
+    [GraphQLError: Variable "$input" got invalid value 3 at "input.title"; Expected type ConstraintTitle. Must be greater than 3],
   ],
   "extensions": undefined,
   "http": Object {
@@ -488,7 +488,7 @@ exports[`INPUT_FIELD_DEFINITION Int validate @constraint #max should fail 1`] = 
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value 5 at "input.title"; Expected type ConstraintNumber. Must be no greater than 3],
+    [GraphQLError: Variable "$input" got invalid value 5 at "input.title"; Expected type ConstraintTitle. Must be no greater than 3],
   ],
   "extensions": undefined,
   "http": Object {
@@ -518,7 +518,7 @@ exports[`INPUT_FIELD_DEFINITION Int validate @constraint #min should fail 1`] = 
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value 2 at "input.title"; Expected type ConstraintNumber. Must be at least 3],
+    [GraphQLError: Variable "$input" got invalid value 2 at "input.title"; Expected type ConstraintTitle. Must be at least 3],
   ],
   "extensions": undefined,
   "http": Object {
@@ -548,7 +548,7 @@ exports[`INPUT_FIELD_DEFINITION Int validate @constraint #multipleOf should fail
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value 7 at "input.title"; Expected type ConstraintNumber. Must be a multiple of 2],
+    [GraphQLError: Variable "$input" got invalid value 7 at "input.title"; Expected type ConstraintTitle. Must be a multiple of 2],
   ],
   "extensions": undefined,
   "http": Object {

--- a/test/__snapshots__/string.test.js.snap
+++ b/test/__snapshots__/string.test.js.snap
@@ -702,7 +702,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #contains should fai
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "Oh no" at "input.title"; Expected type ConstraintString. Must contain 💩],
+    [GraphQLError: Variable "$input" got invalid value "Oh no" at "input.title"; Expected type ConstraintTitle. Must contain 💩],
   ],
   "extensions": undefined,
   "http": Object {
@@ -732,7 +732,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #endsWith should fai
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "💩 no" at "input.title"; Expected type ConstraintString. Must end with 💩],
+    [GraphQLError: Variable "$input" got invalid value "💩 no" at "input.title"; Expected type ConstraintTitle. Must end with 💩],
   ],
   "extensions": undefined,
   "http": Object {
@@ -762,7 +762,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #format #byte should
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "£££" at "input.title"; Expected type ConstraintString. Must be in byte format],
+    [GraphQLError: Variable "$input" got invalid value "£££" at "input.title"; Expected type ConstraintTitle. Must be in byte format],
   ],
   "extensions": undefined,
   "http": Object {
@@ -792,7 +792,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #format #date should
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "too late" at "input.title"; Expected type ConstraintString. Must be a date in ISO 8601 format],
+    [GraphQLError: Variable "$input" got invalid value "too late" at "input.title"; Expected type ConstraintTitle. Must be a date in ISO 8601 format],
   ],
   "extensions": undefined,
   "http": Object {
@@ -822,7 +822,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #format #date-time s
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "no time" at "input.title"; Expected type ConstraintString. Must be a date-time in RFC 3339 format],
+    [GraphQLError: Variable "$input" got invalid value "no time" at "input.title"; Expected type ConstraintTitle. Must be a date-time in RFC 3339 format],
   ],
   "extensions": undefined,
   "http": Object {
@@ -852,7 +852,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #format #email shoul
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintString. Must be in email format],
+    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintTitle. Must be in email format],
   ],
   "extensions": undefined,
   "http": Object {
@@ -882,7 +882,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #format #ipv4 should
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintString. Must be in IP v4 format],
+    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintTitle. Must be in IP v4 format],
   ],
   "extensions": undefined,
   "http": Object {
@@ -912,7 +912,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #format #ipv6 should
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintString. Must be in IP v6 format],
+    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintTitle. Must be in IP v6 format],
   ],
   "extensions": undefined,
   "http": Object {
@@ -942,7 +942,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #format #unknowm sho
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "a" at "input.title"; Expected type ConstraintString. Invalid format type unknowm],
+    [GraphQLError: Variable "$input" got invalid value "a" at "input.title"; Expected type ConstraintTitle. Invalid format type unknowm],
   ],
   "extensions": undefined,
   "http": Object {
@@ -957,7 +957,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #format #uri should 
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintString. Must be in URI format],
+    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintTitle. Must be in URI format],
   ],
   "extensions": undefined,
   "http": Object {
@@ -987,7 +987,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #format #uuid should
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintString. Must be in UUID format],
+    [GraphQLError: Variable "$input" got invalid value "null" at "input.title"; Expected type ConstraintTitle. Must be in UUID format],
   ],
   "extensions": undefined,
   "http": Object {
@@ -1017,7 +1017,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #maxLength should fa
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "fail💩" at "input.title"; Expected type ConstraintString. Must be no more than 3 characters in length],
+    [GraphQLError: Variable "$input" got invalid value "fail💩" at "input.title"; Expected type ConstraintTitle. Must be no more than 3 characters in length],
   ],
   "extensions": undefined,
   "http": Object {
@@ -1072,7 +1072,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #minLength should fa
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "a💩" at "input.title"; Expected type ConstraintString. Must be at least 3 characters in length],
+    [GraphQLError: Variable "$input" got invalid value "a💩" at "input.title"; Expected type ConstraintTitle. Must be at least 3 characters in length],
   ],
   "extensions": undefined,
   "http": Object {
@@ -1127,7 +1127,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #notContains should 
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "It contains 💩 the sign" at "input.title"; Expected type ConstraintString. Must not contain 💩],
+    [GraphQLError: Variable "$input" got invalid value "It contains 💩 the sign" at "input.title"; Expected type ConstraintTitle. Must not contain 💩],
   ],
   "extensions": undefined,
   "http": Object {
@@ -1157,7 +1157,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #passwordScore shoul
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "got 💩" at "input.title"; Expected type ConstraintString. Password for title is not strong enough to reach a score of 3],
+    [GraphQLError: Variable "$input" got invalid value "got 💩" at "input.title"; Expected type ConstraintTitle. Password for title is not strong enough to reach a score of 3],
   ],
   "extensions": undefined,
   "http": Object {
@@ -1202,7 +1202,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #pattern should fail
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "£££" at "input.title"; Expected type ConstraintString. Must match ^[0-9a-zA-Z]*$],
+    [GraphQLError: Variable "$input" got invalid value "£££" at "input.title"; Expected type ConstraintTitle. Must match ^[0-9a-zA-Z]*$],
   ],
   "extensions": undefined,
   "http": Object {
@@ -1232,7 +1232,7 @@ exports[`INPUT_FIELD_DEFINITION String validate @constraint #startsWith should f
 Object {
   "data": undefined,
   "errors": Array [
-    [GraphQLError: Variable "$input" got invalid value "no 💩" at "input.title"; Expected type ConstraintString. Must start with 💩],
+    [GraphQLError: Variable "$input" got invalid value "no 💩" at "input.title"; Expected type ConstraintTitle. Must start with 💩],
   ],
   "extensions": undefined,
   "http": Object {


### PR DESCRIPTION
It's not possible to use more than 1 constraint per scalar type because wrap type name is fixed and will be saved to types map only once.

Changes:
- generate wrap type name on the fly.